### PR TITLE
Fix: duckdb ocel export missing e2o

### DIFF
--- a/process_mining/Cargo.toml
+++ b/process_mining/Cargo.toml
@@ -54,3 +54,7 @@ token_based_replay = ["dep:nalgebra"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[example]]
+name = "ocel_duckdb_export"
+required-features = ["ocel-duckdb"]

--- a/process_mining/examples/ocel_duckdb_export.rs
+++ b/process_mining/examples/ocel_duckdb_export.rs
@@ -1,0 +1,22 @@
+use std::{collections::HashSet, env::args, path::PathBuf};
+
+use process_mining::{import_ocel_xml_file, ocel::sql::export_ocel_duckdb_to_path};
+
+pub fn main() {
+    let path_opt = args().nth(1);
+    if let Some(path) = path_opt.map(PathBuf::from) {
+        let mut ocel = import_ocel_xml_file(&path);
+        // Including invalid E2O relations (i.e., to objects that do not exist) can cause corrupted or incomplete SQL exports
+        // Thus, we filter the E2O relations to only keep valid ones
+        let all_obj_ids: HashSet<_> = ocel.objects.iter().map(|o| &o.id).collect();
+        for e in &mut ocel.events {
+            e.relationships
+                .retain(|r| all_obj_ids.contains(&r.object_id));
+        }
+        let export_path = path.with_file_name(format!(
+            "{}.duck",
+            path.file_name().and_then(|n| n.to_str()).unwrap_or("ocel")
+        ));
+        export_ocel_duckdb_to_path(&ocel, &export_path).unwrap();
+    }
+}

--- a/process_mining/src/event_log/ocel/sql/duckdb/duckdb_ocel_import.rs
+++ b/process_mining/src/event_log/ocel/sql/duckdb/duckdb_ocel_import.rs
@@ -161,7 +161,13 @@ pub fn import_ocel_duckdb_from_con(con: Connection) -> Result<OCEL, ::duckdb::Er
             let changed_val = ob_type_attrs
                 .iter()
                 .find(|at| at.name == changed_field)
-                .ok_or(::duckdb::Error::InvalidQuery)
+                .ok_or_else(|| {
+                    println!(
+                        "Could not get change field for {:?} in {:?}",
+                        changed_field, ob_type_attrs
+                    );
+                    ::duckdb::Error::InvalidQuery
+                })
                 .and_then(|attr| get_row_attribute_value(attr, x))
                 .unwrap();
             Ok::<(String, _, String, OCELAttributeValue), ::duckdb::Error>((

--- a/process_mining/src/event_log/ocel/sql/duckdb/mod.rs
+++ b/process_mining/src/event_log/ocel/sql/duckdb/mod.rs
@@ -101,4 +101,26 @@ mod duckdb_tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_duckdb_containers_round_trip_ocel() -> Result<(), ::duckdb::Error> {
+        let path = get_test_data_path()
+            .join("ocel")
+            .join("ContainerLogistics.xml");
+        let ocel = import_ocel_xml_file(path);
+        let export_path = get_test_data_path()
+            .join("export")
+            .join("ContainerLogistics.duckdb");
+        let _ = std::fs::remove_file(&export_path);
+        export_ocel_duckdb_to_path(&ocel, &export_path).unwrap();
+        let ocel2 = import_ocel_duckdb_from_path(&export_path).unwrap();
+
+        assert_eq!(ocel.events.len(), ocel2.events.len());
+        assert_eq!(ocel.objects.len(), ocel2.objects.len());
+        assert_eq!(ocel.event_types.len(), ocel2.event_types.len());
+        assert_eq!(ocel.object_types.len(), ocel2.object_types.len());
+        drop(ocel);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Some stability improvements to address issues for certain OCELs with problems (e.g., invalids E2O relationships).