### PR TITLE
Fix: Language Abstraction Conformance Values

### DIFF
--- a/process_mining/src/core/process_models/object_centric/ocpt/object_centric_process_tree_struct.rs
+++ b/process_mining/src/core/process_models/object_centric/ocpt/object_centric_process_tree_struct.rs
@@ -205,7 +205,7 @@ pub enum OCPTOperatorType {
 ///
 /// Object-centric process tree struct that contains [`OCPTNode`] as root
 ///
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OCPT {
     /// The root of the object-centric process tree
     pub root: OCPTNode,


### PR DESCRIPTION
Addressed error shown by reproduction example
+ added test cases for two cases (same ocpt and one ocpt and OCEL for which it should have perfect fitness)