### PR TITLE
Add options type parameter and known formats for import/export io traits

### DIFF
--- a/process_mining/src/conformance/object_centric/object_centric_language_abstraction.rs
+++ b/process_mining/src/conformance/object_centric/object_centric_language_abstraction.rs
@@ -1010,7 +1010,7 @@ mod tests {
         );
         const EXPECTED_PRECISION: f64 = 0.6876033057851241;
         assert!(
-            (precision - EXPECTED_PRECISION).abs() < f64::EPSILON,
+            (precision - EXPECTED_PRECISION).abs() < 0.00000001,
             "Wrong precision: got {}!={} <- should be this value",
             precision,
             EXPECTED_PRECISION

--- a/process_mining/src/core/event_data/case_centric/io.rs
+++ b/process_mining/src/core/event_data/case_centric/io.rs
@@ -86,13 +86,13 @@ impl Importable for EventLog {
                 let log: EventLog = serde_json::from_reader(reader)?;
                 Ok(log)
             }
-            _ if format.ends_with("xes") => {
-                let buf_reader = BufReader::new(reader);
-                import_xes(buf_reader, options).map_err(EventLogIOError::Xes)
-            }
             _ if format.ends_with("xes.gz") => {
                 let gz = flate2::read::GzDecoder::new(reader);
                 let buf_reader = BufReader::new(gz);
+                import_xes(buf_reader, options).map_err(EventLogIOError::Xes)
+            }
+            _ if format.ends_with("xes") => {
+                let buf_reader = BufReader::new(reader);
                 import_xes(buf_reader, options).map_err(EventLogIOError::Xes)
             }
             _ => Err(EventLogIOError::UnsupportedFormat(format.to_string())),

--- a/process_mining/src/core/event_data/case_centric/io.rs
+++ b/process_mining/src/core/event_data/case_centric/io.rs
@@ -1,7 +1,6 @@
 //! IO implementations for `EventLog`
 
 use std::io::{BufReader, Read, Write};
-use std::path::Path;
 
 use crate::core::event_data::case_centric::xes::export_xes::export_xes_event_log;
 use crate::core::event_data::case_centric::xes::import_xes::{
@@ -97,17 +96,6 @@ impl Importable for EventLog {
                 import_xes(buf_reader, options).map_err(EventLogIOError::Xes)
             }
             _ => Err(EventLogIOError::UnsupportedFormat(format.to_string())),
-        }
-    }
-
-    fn infer_format(path: &Path) -> Option<String> {
-        let p = path.to_string_lossy().to_lowercase();
-        if p.ends_with(".xes.gz") {
-            Some("xes.gz".to_string())
-        } else {
-            path.extension()
-                .and_then(|e| e.to_str())
-                .map(|s| s.to_lowercase())
         }
     }
 

--- a/process_mining/src/core/event_data/case_centric/utils/activity_projection.rs
+++ b/process_mining/src/core/event_data/case_centric/utils/activity_projection.rs
@@ -318,15 +318,11 @@ impl Importable for EventLogActivityProjection {
         format: &str,
         _: Self::ImportOptions,
     ) -> Result<Self, Self::Error> {
-        if format == "json" || format.ends_with(".json") {
+        if format.ends_with("json") {
             let reader = std::io::BufReader::new(reader);
             let res: Self = serde_json::from_reader(reader)?;
             Ok(res)
-        } else if format == "xes"
-            || format == "xes.gz"
-            || format.ends_with(".xes")
-            || format.ends_with(".xes.gz")
-        {
+        } else if format.ends_with("xes") || format.ends_with("xes.gz") {
             let log = EventLog::import_from_reader(reader, format)?;
             Ok((&log).into())
         } else {
@@ -362,7 +358,7 @@ impl Exportable for EventLogActivityProjection {
         format: &str,
         _: Self::ExportOptions,
     ) -> Result<(), Self::Error> {
-        if format == "json" || format.ends_with(".json") {
+        if format.ends_with("json") {
             serde_json::to_writer(writer, self)?;
             Ok(())
         } else {

--- a/process_mining/src/core/event_data/object_centric/io.rs
+++ b/process_mining/src/core/event_data/object_centric/io.rs
@@ -146,9 +146,9 @@ impl Importable for OCEL {
                     .map_err(OCELIOError::Sqlite)
             }
             #[cfg(not(feature = "ocel-sqlite"))]
-            return Err(OCELIOError::UnsupportedFormat(
+            Err(OCELIOError::UnsupportedFormat(
                 "SQLite support not enabled".to_string(),
-            ));
+            ))
         } else if format.ends_with("duckdb") {
             Err(OCELIOError::UnsupportedFormat(
                 "DuckDB import from reader not supported".to_string(),

--- a/process_mining/src/core/event_data/object_centric/io.rs
+++ b/process_mining/src/core/event_data/object_centric/io.rs
@@ -291,7 +291,9 @@ impl Exportable for OCEL {
                 writer, self,
             )
             .map_err(OCELIOError::Xml)
-        } else if format.ends_with("sqlite") || format.ends_with("db") {
+        } else if format.ends_with("sqlite")
+            || (format.ends_with("db") && !format.ends_with("duckdb"))
+        {
             #[cfg(feature = "ocel-sqlite")]
             {
                 let b = export_ocel_sqlite_to_vec(self).map_err(|e| match e {

--- a/process_mining/src/core/event_data/object_centric/io.rs
+++ b/process_mining/src/core/event_data/object_centric/io.rs
@@ -3,6 +3,7 @@
 use std::io::{Read, Write};
 use std::path::Path;
 
+#[cfg(feature = "ocel-sqlite")]
 use crate::core::event_data::object_centric::ocel_sql::export_ocel_sqlite_to_vec;
 #[cfg(any(feature = "ocel-duckdb", feature = "ocel-sqlite"))]
 use crate::core::event_data::object_centric::ocel_sql::DatabaseError;
@@ -115,7 +116,7 @@ impl Importable for OCEL {
     }
 
     fn import_from_reader_with_options<R: Read>(
-        mut reader: R,
+        #[allow(unused_mut)] mut reader: R,
         format: &str,
         _: Self::ImportOptions,
     ) -> Result<Self, Self::Error> {
@@ -272,7 +273,7 @@ impl Exportable for OCEL {
 
     fn export_to_writer_with_options<W: Write>(
         &self,
-        mut writer: W,
+        #[allow(unused_mut)] mut writer: W,
         format: &str,
         _: Self::ExportOptions,
     ) -> Result<(), Self::Error> {
@@ -292,9 +293,7 @@ impl Exportable for OCEL {
                 DatabaseError::DUCKDB(e) => OCELIOError::DuckDB(e),
             })?;
             writer.write_all(&b)?;
-            Err(OCELIOError::UnsupportedFormat(
-                "SQLite export to writer not supported".to_string(),
-            ))
+            Ok(())
         } else if format.ends_with("duckdb") {
             Err(OCELIOError::UnsupportedFormat(
                 "DuckDB export to writer not supported".to_string(),

--- a/process_mining/src/core/event_data/object_centric/linked_ocel/index_linked_ocel.rs
+++ b/process_mining/src/core/event_data/object_centric/linked_ocel/index_linked_ocel.rs
@@ -458,7 +458,7 @@ impl Importable for IndexLinkedOCEL {
         format: &str,
         _: Self::ImportOptions,
     ) -> Result<Self, Self::Error> {
-        if format == "json" || format.ends_with(".json") {
+        if format.ends_with("json") {
             let reader = std::io::BufReader::new(reader);
             let res: Self = serde_json::from_reader(reader)?;
             Ok(res)
@@ -496,7 +496,7 @@ impl Exportable for IndexLinkedOCEL {
         format: &str,
         _: Self::ExportOptions,
     ) -> Result<(), Self::Error> {
-        if format == "json" || format.ends_with(".json") {
+        if format.ends_with("json") {
             serde_json::to_writer(writer, self)?;
             Ok(())
         } else {

--- a/process_mining/src/core/io.rs
+++ b/process_mining/src/core/io.rs
@@ -1,17 +1,79 @@
 use std::io::{Read, Write};
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
+
+/// Try to infer file format from a path
+///
+/// Handles cases like test.file-abc.xes.gz -> xes.gz
+pub fn infer_format_from_path(path: &Path) -> Option<String> {
+    let path_str = path.to_string_lossy().to_lowercase();
+    if path_str.ends_with(".gz") {
+        return match path
+            .file_stem()
+            .and_then(|e| e.to_str())
+            .and_then(|e| e.rsplit_once('.'))
+            .map(|(_name, ext)| ext)
+        {
+            Some(ext) => Some(format!("{ext}.gz")),
+            None => Some("gz".to_string()),
+        };
+    }
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_lowercase())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// File Extension and MIME Type
+///
+/// Example: `xes.gz` (Extension), `application/gzip` (MIME Type)
+pub struct ExtensionWithMime {
+    /// Extension part (e.g., `xes.gz`)
+    pub extension: String,
+    /// MIME part (e.g., `application/gzip`)
+    pub mime: String,
+}
+impl ExtensionWithMime {
+    /// Construct MIME Type
+    pub fn new(extension: impl Into<String>, mime: impl Into<String>) -> Self {
+        Self {
+            extension: extension.into(),
+            mime: mime.into(),
+        }
+    }
+}
+
 /// Trait for importing types from a file path or reader
 pub trait Importable: Sized {
     /// The error type returned by import operations
     type Error: std::error::Error + Send + Sync + 'static + From<std::io::Error>;
 
-    /// Import from a reader, specifying the format.
-    fn import_from_reader<R: Read>(reader: R, format: &str) -> Result<Self, Self::Error>;
+    /// Import options
+    type ImportOptions: Default;
 
-    /// Import from a file path, optionally specifying the format.
-    /// If format is None, it should be inferred from the file extension.
+    /// Import from a reader, specifying the format.
+    fn import_from_reader<R: Read>(reader: R, data_format: &str) -> Result<Self, Self::Error> {
+        Self::import_from_reader_with_options(reader, data_format, Self::ImportOptions::default())
+    }
+
+    /// Import from a reader, specifying the format and import options.
+    fn import_from_reader_with_options<R: Read>(
+        reader: R,
+        data_format: &str,
+        options: Self::ImportOptions,
+    ) -> Result<Self, Self::Error>;
+
+    /// Import from a file path, parsing the format from the file extension.
     fn import_from_path<P: AsRef<Path>>(path: P) -> Result<Self, Self::Error> {
+        Self::import_from_path_with_options(path, Self::ImportOptions::default())
+    }
+
+    /// Import from a file path with the specified import options, parsing the format from the file extension.
+    fn import_from_path_with_options<P: AsRef<Path>>(
+        path: P,
+        o: Self::ImportOptions,
+    ) -> Result<Self, Self::Error> {
         let path = path.as_ref();
         let format = Self::infer_format(path).ok_or_else(|| {
             std::io::Error::new(
@@ -22,24 +84,31 @@ pub trait Importable: Sized {
 
         let file = std::fs::File::open(path)?;
         let reader = std::io::BufReader::new(file);
-        Self::import_from_reader(reader, &format)
+        Self::import_from_reader_with_options(reader, &format, o)
     }
 
     /// Import from a byte slice, specifying the format.
-    fn import_from_bytes(bytes: &[u8], format: &str) -> Result<Self, Self::Error> {
-        Self::import_from_reader(std::io::Cursor::new(bytes), format)
+    fn import_from_bytes(bytes: &[u8], data_format: &str) -> Result<Self, Self::Error> {
+        Self::import_from_bytes_with_options(bytes, data_format, Self::ImportOptions::default())
+    }
+    /// Import from a byte slice in the given format with specified import options.
+    fn import_from_bytes_with_options(
+        bytes: &[u8],
+        data_format: &str,
+        options: Self::ImportOptions,
+    ) -> Result<Self, Self::Error> {
+        Self::import_from_reader_with_options(std::io::Cursor::new(bytes), data_format, options)
     }
 
-    /// Infer format from path. Can be overridden for complex extensions (e.g., .xes.gz).
+    /// Infer format from path. Can be overridden for complex extensions.
     fn infer_format(path: &Path) -> Option<String> {
-        let path_str = path.to_string_lossy().to_lowercase();
-        if path_str.ends_with(".xes.gz") {
-            return Some("xes.gz".to_string());
-        }
-        path.extension()
-            .and_then(|e| e.to_str())
-            .map(|s| s.to_lowercase())
+        infer_format_from_path(path)
     }
+
+    /// Get known import formats
+    ///
+    /// This function can be used to suggest import formats or contruct file chooser filters
+    fn known_import_formats() -> Vec<ExtensionWithMime>;
 }
 
 /// Trait for exporting types to a file path or writer
@@ -47,12 +116,28 @@ pub trait Exportable {
     /// The error type returned by export operations
     type Error: std::error::Error + Send + Sync + 'static + From<std::io::Error>;
 
-    /// Export to a writer, specifying the format.
-    fn export_to_writer<W: Write>(&self, writer: W, format: &str) -> Result<(), Self::Error>;
+    /// Export options
+    type ExportOptions: Default;
 
-    /// Export to a file path, optionally specifying the format.
-    /// If format is None, it should be inferred from the file extension.
-    fn export_to_path<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+    /// Export to a writer, specifying the format and export options.
+    fn export_to_writer_with_options<W: Write>(
+        &self,
+        writer: W,
+        format: &str,
+        options: Self::ExportOptions,
+    ) -> Result<(), Self::Error>;
+
+    /// Export to a writer, specifying the format.
+    fn export_to_writer<W: Write>(&self, writer: W, format: &str) -> Result<(), Self::Error> {
+        self.export_to_writer_with_options(writer, format, Self::ExportOptions::default())
+    }
+
+    /// Export to a file path, optionally specifying the format and import options.
+    fn export_to_path_with_options<P: AsRef<Path>>(
+        &self,
+        path: P,
+        options: Self::ExportOptions,
+    ) -> Result<(), Self::Error> {
         let path = path.as_ref();
         let format = Self::infer_format(path).ok_or_else(|| {
             std::io::Error::new(
@@ -63,24 +148,83 @@ pub trait Exportable {
 
         let file = std::fs::File::create(path)?;
         let writer = std::io::BufWriter::new(file);
-        Self::export_to_writer(self, writer, &format)
+        self.export_to_writer_with_options(writer, &format, options)
     }
 
-    /// Infer format from path. Can be overridden for complex extensions.
-    fn infer_format(path: &Path) -> Option<String> {
-        let path_str = path.to_string_lossy().to_lowercase();
-        if path_str.ends_with(".xes.gz") {
-            return Some("xes.gz".to_string());
-        }
-        path.extension()
-            .and_then(|e| e.to_str())
-            .map(|s| s.to_lowercase())
+    /// Export to a file path, optionally specifying the format.
+    fn export_to_path<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error> {
+        self.export_to_path_with_options(path, Self::ExportOptions::default())
     }
+
+    /// Export as a byte array with the specified options
+    fn export_to_bytes_with_options(
+        &self,
+        format: &str,
+        options: Self::ExportOptions,
+    ) -> Result<Vec<u8>, Self::Error> {
+        let mut ret = Vec::new();
+        self.export_to_writer_with_options(&mut ret, format, options)?;
+        Ok(ret)
+    }
+
+    /// Export as a byte array
+    fn export_to_bytes(&self, format: &str) -> Result<Vec<u8>, Self::Error> {
+        self.export_to_bytes_with_options(format, Self::ExportOptions::default())
+    }
+
+    /// Infer format from path.
+    fn infer_format(path: &Path) -> Option<String> {
+        infer_format_from_path(path)
+    }
+    /// Get known export formats
+    ///
+    /// This function can be used to suggest exports formats or contruct file chooser filters
+    fn known_export_formats() -> Vec<ExtensionWithMime>;
 }
 
-#[test]
-fn test_stuff() {
-    let log = super::EventLog::default();
-    let mut bytes = Vec::new();
-    log.export_to_writer(&mut bytes, ".xes.gz").unwrap();
+#[cfg(test)]
+mod test {
+    use super::infer_format_from_path;
+    use crate::{core::io::ExtensionWithMime, Exportable, Importable};
+
+    #[test]
+    fn test_extension_extraction() {
+        let x = infer_format_from_path("test.xes.gz".as_ref());
+        assert_eq!(x, Some("xes.gz".to_string()));
+        let x = infer_format_from_path("this.is.a.test.json.gz".as_ref());
+        assert_eq!(x, Some("json.gz".to_string()));
+        let x = infer_format_from_path("this.is.a.test.json".as_ref());
+        assert_eq!(x, Some("json".to_string()));
+        let x = infer_format_from_path("simple_archive.gz".as_ref());
+        assert_eq!(x, Some("gz".to_string()));
+    }
+
+    #[test]
+    fn test_stuff() {
+        let log = crate::EventLog::default();
+        let mut bytes = Vec::new();
+        log.export_to_writer(&mut bytes, ".xes.gz").unwrap();
+    }
+
+    #[test]
+    fn test_no_import_options() {
+        struct X;
+        impl Importable for X {
+            type Error = std::io::Error;
+            type ImportOptions = ();
+            fn import_from_reader_with_options<R: std::io::Read>(
+                _: R,
+                _: &str,
+                _: Self::ImportOptions,
+            ) -> Result<Self, Self::Error> {
+                Ok(X)
+            }
+
+            fn known_import_formats() -> Vec<ExtensionWithMime> {
+                vec![]
+            }
+        }
+
+        X::import_from_bytes(&[], ".test.gz").expect("Input should not matter.");
+    }
 }

--- a/process_mining/src/core/io.rs
+++ b/process_mining/src/core/io.rs
@@ -35,7 +35,7 @@ pub struct ExtensionWithMime {
     pub mime: String,
 }
 impl ExtensionWithMime {
-    /// Construct MIME Type
+    /// Construct Extension with MIME Type
     pub fn new(extension: impl Into<String>, mime: impl Into<String>) -> Self {
         Self {
             extension: extension.into(),

--- a/process_mining/src/core/io.rs
+++ b/process_mining/src/core/io.rs
@@ -107,7 +107,7 @@ pub trait Importable: Sized {
 
     /// Get known import formats
     ///
-    /// This function can be used to suggest import formats or contruct file chooser filters
+    /// This function can be used to suggest import formats or construct file chooser filters
     fn known_import_formats() -> Vec<ExtensionWithMime>;
 }
 
@@ -178,7 +178,7 @@ pub trait Exportable {
     }
     /// Get known export formats
     ///
-    /// This function can be used to suggest exports formats or contruct file chooser filters
+    /// This function can be used to suggest exports formats or construct file chooser filters
     fn known_export_formats() -> Vec<ExtensionWithMime>;
 }
 

--- a/process_mining/src/core/io.rs
+++ b/process_mining/src/core/io.rs
@@ -132,7 +132,7 @@ pub trait Exportable {
         self.export_to_writer_with_options(writer, format, Self::ExportOptions::default())
     }
 
-    /// Export to a file path, optionally specifying the format and import options.
+    /// Export to a file path, optionally specifying the format and export options.
     fn export_to_path_with_options<P: AsRef<Path>>(
         &self,
         path: P,

--- a/process_mining/src/core/process_models/case_centric/petri_net/io.rs
+++ b/process_mining/src/core/process_models/case_centric/petri_net/io.rs
@@ -71,7 +71,7 @@ impl Importable for PetriNet {
         format: &str,
         _: Self::ImportOptions,
     ) -> Result<Self, Self::Error> {
-        if format == "pnml" || format.ends_with(".pnml") {
+        if format.ends_with("pnml") {
             let mut buf_reader = std::io::BufReader::new(reader);
             import_pnml_reader(&mut buf_reader).map_err(PetriNetIOError::Pnml)
         } else {
@@ -94,7 +94,7 @@ impl Exportable for PetriNet {
         format: &str,
         _: Self::ExportOptions,
     ) -> Result<(), Self::Error> {
-        if format == "pnml" || format.ends_with(".pnml") {
+        if format.ends_with("pnml") {
             export_petri_net_to_pnml(self, writer).map_err(PetriNetIOError::Xml)
         } else {
             Err(PetriNetIOError::UnsupportedFormat(format.to_string()))


### PR DESCRIPTION
- Add `ImportOptions` and `ExportOptions` for `Importable` / `Exportable` traits.
- Add `known_import_formats` and `known_export_formats` functions to these traits.
- Improved format from path inference (`test.anything.gz` -> `anything.gz`