### PR TITLE
refactor: enforce Clippy print restrictions and migrate to log macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,10 +64,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "approx"
@@ -628,6 +672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "comfy-table"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1046,29 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -1738,6 +1811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +1830,30 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "jobserver"
@@ -1932,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -1965,6 +2068,7 @@ dependencies = [
 name = "macros_process_mining"
 version = "0.5.5"
 dependencies = [
+ "log",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -2171,6 +2275,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -2890,6 +3000,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,6 +3068,7 @@ dependencies = [
  "inventory",
  "itertools",
  "kuzu",
+ "log",
  "macros_process_mining",
  "nalgebra",
  "ordered-float",
@@ -3065,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3077,6 +3203,8 @@ name = "r4pm"
 version = "0.5.5"
 dependencies = [
  "anstyle",
+ "env_logger",
+ "log",
  "process_mining",
  "serde",
  "serde_json",
@@ -3244,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3256,9 +3384,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4388,6 +4516,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/macros_process_mining/Cargo.toml
+++ b/macros_process_mining/Cargo.toml
@@ -12,3 +12,4 @@ proc-macro = true
 syn = { version = "2.0", features = ["full", "extra-traits", "fold"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+log = "0.4.29"

--- a/process_mining/Cargo.toml
+++ b/process_mining/Cargo.toml
@@ -37,6 +37,7 @@ uuid = {version = "1.16.0", features = ["v4", "serde"]}
 schemars = { version = "1.1.0", features = ["chrono04", "uuid1"]}
 inventory = { version = "0.3", optional = true }
 csv = "1.4.0"
+log = "0.4.29"
 
 [features]
 

--- a/process_mining/examples/event_log_stats.rs
+++ b/process_mining/examples/event_log_stats.rs
@@ -2,7 +2,6 @@ use process_mining::{EventLog, Importable};
 use std::env;
 use std::error::Error;
 use std::path::PathBuf;
-
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {

--- a/process_mining/src/core/event_data/case_centric/dataframe/mod.rs
+++ b/process_mining/src/core/event_data/case_centric/dataframe/mod.rs
@@ -1,11 +1,11 @@
 //! Conversion of Event Data from/to polars `DataFrame`s
 //!
 //! 🔐 Requires the `dataframes` feature to be enabled.
-use std::{collections::HashSet, time::Instant};
-
 use chrono::DateTime;
+use log::{debug, error, info, trace, warn};
 use polars::prelude::*;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use std::{collections::HashSet, time::Instant};
 
 use crate::core::{
     event_data::case_centric::{
@@ -81,11 +81,10 @@ fn attribute_value_to_any_value<'a>(from: &AttributeValue) -> AnyValue<'a> {
 ///
 pub fn convert_log_to_dataframe(
     log: &EventLog,
-    print_debug: bool,
+    _print_debug: bool, //Replaced print with debug statement
 ) -> Result<DataFrame, PolarsError> {
-    if print_debug {
-        println!("Starting converting log to DataFrame");
-    }
+    debug!("Starting converting log to DataFrame");
+
     let mut now = Instant::now();
     let all_attributes: HashSet<String> = log
         .traces
@@ -110,9 +109,7 @@ pub fn convert_log_to_dataframe(
         })
         .flatten()
         .collect();
-    if print_debug {
-        println!("Gathering all attributes took {:.2?}", now.elapsed());
-    }
+    debug!("Gathering all attributes took {:.2?}", now.elapsed());
     now = Instant::now();
     let x: Vec<Series> = all_attributes
         .par_iter()
@@ -148,9 +145,7 @@ pub fn convert_log_to_dataframe(
             let mut unique_dtypes: HashSet<DataType> = entries.iter().map(|v| v.dtype()).collect();
             unique_dtypes.remove(&DataType::Null);
             if unique_dtypes.len() > 1 {
-                eprintln!(
-                    "Warning: Attribute {k} contains values of different dtypes ({unique_dtypes:?})"
-                );
+                error!("Attribute {k} contains values of different dtypes ({unique_dtypes:?})");
                 if unique_dtypes
                     == vec![DataType::Float64, DataType::Int64]
                         .into_iter()
@@ -177,12 +172,12 @@ pub fn convert_log_to_dataframe(
             Series::new(k.into(), entries)
         })
         .collect();
-    if print_debug {
-        println!(
-            "Creating a Series for every Attribute took {:.2?}",
-            now.elapsed()
-        );
-    }
+
+    debug!(
+        "Creating a Series for every Attribute took {:.2?}",
+        now.elapsed()
+    );
+
     now = Instant::now();
     let df = unsafe {
         DataFrame::new_no_checks(

--- a/process_mining/src/core/event_data/case_centric/utils/activity_projection.rs
+++ b/process_mining/src/core/event_data/case_centric/utils/activity_projection.rs
@@ -3,12 +3,12 @@
 //! Only considers traces as sequences of activities.
 //!
 //! Cases with the same activity trace are aggregated as frequencies.
-use std::collections::{HashMap, HashSet};
-
+use log::{debug, error, info, trace, warn};
 use macros_process_mining::{register_binding, RegistryEntity};
 use rayon::prelude::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 use crate::core::event_data::case_centric::io::EventLogIOError;
 use crate::core::io::{Exportable, ExtensionWithMime, Importable};
@@ -172,7 +172,7 @@ pub fn add_start_end_acts_proj(log: &mut EventLogActivityProjection) {
     let mut should_add_start = true;
     let start_act = match log.act_to_index.get(START_ACTIVITY) {
         Some(a) => {
-            eprintln!("Start activity ({START_ACTIVITY}) already present in activity set! Will skip adding a start activity to every trace, which might not be the desired outcome.");
+            error!("Start activity ({START_ACTIVITY}) already present in activity set! Will skip adding a start activity to every trace, which might not be the desired outcome.");
             should_add_start = false;
             *a
         }
@@ -187,7 +187,7 @@ pub fn add_start_end_acts_proj(log: &mut EventLogActivityProjection) {
     let mut should_add_end = true;
     let end_act = match log.act_to_index.get(END_ACTIVITY) {
         Some(a) => {
-            eprintln!("End activity ({END_ACTIVITY}) already present in activity set! Still adding an end activity to every trace, which might not be the desired outcome.");
+            error!("End activity ({END_ACTIVITY}) already present in activity set! Still adding an end activity to every trace, which might not be the desired outcome.");
             should_add_end = false;
             *a
         }

--- a/process_mining/src/core/event_data/case_centric/utils/activity_projection.rs
+++ b/process_mining/src/core/event_data/case_centric/utils/activity_projection.rs
@@ -3,7 +3,7 @@
 //! Only considers traces as sequences of activities.
 //!
 //! Cases with the same activity trace are aggregated as frequencies.
-use log::{debug, error, info, trace, warn};
+use log::error;
 use macros_process_mining::{register_binding, RegistryEntity};
 use rayon::prelude::*;
 use schemars::JsonSchema;

--- a/process_mining/src/core/event_data/case_centric/xes/stream_xes.rs
+++ b/process_mining/src/core/event_data/case_centric/xes/stream_xes.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::core::event_data::case_centric::xes::import_xes::XESImportOptions;
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
 use flate2::read::GzDecoder;
-use log::{debug, error, info, trace, warn};
+use log::error;
 use quick_xml::{escape::unescape, events::BytesStart, Reader};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -748,7 +748,7 @@ impl StreamingXESParser<'_> {
                 },
                 None => {
                     if options.verbose {
-                        eprintln!(
+                        error!(
                         "No current trace when parsing event attribute: Key {key:?}, Value {val:?}"
                     );
                     }

--- a/process_mining/src/core/event_data/case_centric/xes/stream_xes.rs
+++ b/process_mining/src/core/event_data/case_centric/xes/stream_xes.rs
@@ -1,5 +1,3 @@
-use crate::core::event_data::case_centric::xes::import_xes::XESImportOptions;
-
 use super::{
     super::event_log_struct::{
         Attribute, AttributeValue, Attributes, Event, EventLogClassifier, EventLogExtension, Trace,
@@ -7,8 +5,10 @@ use super::{
     },
     import_xes::XESParseError,
 };
+use crate::core::event_data::case_centric::xes::import_xes::XESImportOptions;
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
 use flate2::read::GzDecoder;
+use log::{debug, error, info, trace, warn};
 use quick_xml::{escape::unescape, events::BytesStart, Reader};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -233,7 +233,7 @@ impl StreamingXESParser<'_> {
                                     }
                                     None => {
                                         if self.options.verbose {
-                                            eprintln!("Invalid XES format: Event without trace")
+                                            error!("Invalid XES format: Event without trace")
                                         }
                                     }
                                 }
@@ -268,7 +268,7 @@ impl StreamingXESParser<'_> {
                                 // and nested if symbolizes the logic better
                                 if self.encountered_log {
                                     if self.options.verbose {
-                                        eprintln!(
+                                        error!(
                                         "Encountered two log tags. This is not a valid XES file"
                                     )
                                     }
@@ -466,7 +466,7 @@ impl StreamingXESParser<'_> {
                                                 // This means there was no current nested attribute but the mode indicated otherwise
                                                 // Should thus not happen, but execution can continue.
                                                 if self.options.verbose {
-                                                    eprintln!("Warning: Attribute mode but no open nested attributes!");
+                                                    error!("Attribute mode but no open nested attributes!");
                                                 }
                                                 self.current_mode = self.last_mode_before_attr;
                                             }
@@ -727,7 +727,7 @@ impl StreamingXESParser<'_> {
                 }
                 None => {
                     if options.verbose {
-                        eprintln!(
+                        error!(
                         "No current trace when parsing trace attribute: Key {key:?}, Value {val:?}"
                     );
                     }
@@ -740,7 +740,7 @@ impl StreamingXESParser<'_> {
                     }
                     None => {
                         if options.verbose {
-                            eprintln!(
+                            error!(
                             "No current event when parsing event attribute: Key {key:?}, Value {val:?}"
                         )
                         }
@@ -877,7 +877,7 @@ impl<'a> XESParsingTraceStream<'a> {
                 XESNextStreamElement::Error(e) => Err(e),
                 XESNextStreamElement::Trace(_) => {
                     if s.options.verbose {
-                        eprintln!("Encountered trace before LogData; This should not happen!");
+                        error!("Encountered trace before LogData; This should not happen!");
                     }
                     Err(XESParseError::ExpectedLogData)
                 }
@@ -892,7 +892,7 @@ impl<'a> XESParsingTraceStream<'a> {
             None => {
                 // No log data and no error returned: This should not happen!
                 if s.options.verbose {
-                    eprintln!(
+                    error!(
                     "Iterator initially empty. Expected log data or error; This should not happen!"
                 );
                 }
@@ -1040,7 +1040,7 @@ fn parse_attribute_value_from_tag(
                         Some(dt) => Some(AttributeValue::Date(dt)),
                         None => {
                             if options.verbose {
-                                eprintln!("Failed to parse date from {value:?}");
+                                error!("Failed to parse date from {value:?}");
                             }
                             None
                         }
@@ -1050,7 +1050,7 @@ fn parse_attribute_value_from_tag(
                             Ok(n) => n,
                             Err(e) => {
                                 if options.verbose {
-                                    eprintln!("Could not parse integer {value:?}: Error {e}");
+                                    error!("Could not parse integer {value:?}: Error {e}");
                                 }
                                 i64::default()
                             }
@@ -1062,7 +1062,7 @@ fn parse_attribute_value_from_tag(
                             Ok(n) => n,
                             Err(e) => {
                                 if options.verbose {
-                                    eprintln!("Could not parse float {value:?}: Error {e}");
+                                    error!("Could not parse float {value:?}: Error {e}");
                                 }
                                 f64::default()
                             }
@@ -1074,7 +1074,7 @@ fn parse_attribute_value_from_tag(
                             Ok(n) => n,
                             Err(e) => {
                                 if options.verbose {
-                                    eprintln!("Could not parse boolean {value:?}: Error {e}");
+                                    error!("Could not parse boolean {value:?}: Error {e}");
                                 }
                                 bool::default()
                             }
@@ -1086,7 +1086,7 @@ fn parse_attribute_value_from_tag(
                             Ok(n) => n,
                             Err(e) => {
                                 if options.verbose {
-                                    eprintln!("Could not parse UUID {value:?}: Error {e}");
+                                    error!("Could not parse UUID {value:?}: Error {e}");
                                 }
                                 Uuid::default()
                             }
@@ -1104,9 +1104,7 @@ fn parse_attribute_value_from_tag(
                                 .read_to_string(&mut name_str)
                                 .unwrap_or_default();
                             if options.verbose {
-                                eprintln!(
-                                    "Attribute type not implemented '{name_str}' in mode {m:?}"
-                                );
+                                error!("Attribute type not implemented '{name_str}' in mode {m:?}");
                             }
                             None
                         }

--- a/process_mining/src/core/event_data/object_centric/dataframe/mod.rs
+++ b/process_mining/src/core/event_data/object_centric/dataframe/mod.rs
@@ -1,11 +1,6 @@
-use std::{
-    collections::{HashMap, HashSet},
-    fs::File,
-    path::Path,
-};
-
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
+use log::{debug, error, info, trace, warn};
 use polars::{
     error::{PolarsError, PolarsResult},
     frame::DataFrame,
@@ -15,6 +10,11 @@ use polars::{
         TimeZone,
     },
     series::Series,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    path::Path,
 };
 
 use crate::core::event_data::object_centric::{
@@ -314,9 +314,7 @@ pub fn ocel_to_dataframes(ocel: &OCEL) -> OCELDataFrames {
         .collect();
     // println!("Object attributes: {:?}; Actual object attributes: {:?}", object_attributes.len(), actual_object_attributes.len());
     if !object_attributes.is_superset(&actual_object_attributes) {
-        eprintln!(
-            "Warning: Global object attributes is not a superset of actual object attributes"
-        );
+        error!("Global object attributes is not a superset of actual object attributes");
     }
     let object_attributes_initial: HashSet<String> = object_attributes
         .clone()

--- a/process_mining/src/core/event_data/object_centric/graph_db/ocel_kuzudb.rs
+++ b/process_mining/src/core/event_data/object_centric/graph_db/ocel_kuzudb.rs
@@ -1,9 +1,9 @@
-use polars::{error::PolarsResult, frame::DataFrame, io::SerWriter, prelude::CsvWriter};
-use std::{fs::File, path::Path};
-
 use crate::core::event_data::object_centric::ocel_struct::OCELAttributeType;
 #[cfg(feature = "dataframes")]
 use crate::core::event_data::object_centric::{linked_ocel::LinkedOCELAccess, ocel_struct::OCEL};
+use log::{debug, error, info, trace, warn};
+use polars::{error::PolarsResult, frame::DataFrame, io::SerWriter, prelude::CsvWriter};
+use std::{fs::File, path::Path};
 
 ///
 /// Error encountered while parsing XES
@@ -208,7 +208,7 @@ pub fn export_ocel_to_kuzudb_typed<'a, P: AsRef<Path>>(
                 },
                 attribute_fields_str
             );
-            println!("Query for event type {ev_type}: {q}");
+            trace!("Query for event type {ev_type}: {q}");
             conn.query(&q)?;
 
             conn.query(&format!(
@@ -301,7 +301,7 @@ pub fn export_ocel_to_kuzudb_typed<'a, P: AsRef<Path>>(
             clean_name,
             clean_name,
         );
-        println!(":: {q}");
+        trace!(":: {q}");
         conn.query(&q)?;
         remove_file(path.join("tmp.csv"))?;
 
@@ -413,7 +413,6 @@ mod tests {
         conn.query("CREATE NODE TABLE Event(id STRING PRIMARY KEY, type STRING, time TIMESTAMP);")?;
         let now = Instant::now();
         for i in 0..10_000 {
-            // println!("{i}");
             let query = format!(
                 "CREATE (e:Event {{id: {}, type: 'Pay Order', time: timestamp('{}')}});",
                 i,

--- a/process_mining/src/core/event_data/object_centric/linked_ocel/slim_linked_ocel.rs
+++ b/process_mining/src/core/event_data/object_centric/linked_ocel/slim_linked_ocel.rs
@@ -1,18 +1,18 @@
 //! Linked Slim (i.e., less duplicate fields) OCEL
 //!
 //! Allows easy and efficient access to events, objects, and their relations
+use chrono::{DateTime, FixedOffset};
+use itertools::Itertools;
+use log::{debug, error, info, trace, warn};
+use macros_process_mining::RegistryEntity;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use std::{
     borrow::{Borrow, Cow},
     collections::HashMap,
     io::{Read, Write},
     path::Path,
 };
-
-use chrono::{DateTime, FixedOffset};
-use itertools::Itertools;
-use macros_process_mining::RegistryEntity;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
@@ -614,8 +614,8 @@ impl SlimLinkedOCEL {
         // Pad (or truncate) attributes to expected length; warn on mismatch
         let expected_attr_len = self.event_types[*etype].attributes.len();
         if attributes.len() != expected_attr_len {
-            eprintln!(
-                "[rust4pm] warning: event_type '{}' expects {} attribute value(s), got {}. \
+            error!(
+                "[rust4pm] : event_type '{}' expects {} attribute value(s), got {}. \
                  Padding with Null / truncating. Ensure attribute order matches `add_event_type`.",
                 event_type,
                 expected_attr_len,
@@ -673,8 +673,8 @@ impl SlimLinkedOCEL {
         // Pad (or truncate) attributes to expected length; warn on mismatch
         let expected_attr_len = self.object_types[*otype].attributes.len();
         if attributes.len() != expected_attr_len {
-            eprintln!(
-                "[rust4pm] warning: object_type '{}' expects {} attribute list(s), got {}. \
+            error!(
+                "[rust4pm] : object_type '{}' expects {} attribute list(s), got {}. \
                  Padding with empty / truncating. Ensure attribute order matches `add_object_type`.",
                 object_type,
                 expected_attr_len,
@@ -699,8 +699,8 @@ impl SlimLinkedOCEL {
     /// Returns `true` on success, `false` if either index is out of bounds (with a stderr warning).
     pub fn add_e2o(&mut self, event: EventIndex, object: ObjectIndex, qualifier: String) -> bool {
         if event.0 >= self.events.len() || object.0 >= self.objects.len() {
-            eprintln!(
-                "[rust4pm] warning: add_e2o called with invalid index(es) (event={}, object={}); ignored",
+            error!(
+                "[rust4pm] : add_e2o called with invalid index(es) (event={}, object={}); ignored",
                 event.0, object.0
             );
             return false;
@@ -727,8 +727,8 @@ impl SlimLinkedOCEL {
         qualifier: String,
     ) -> bool {
         if from_obj.0 >= self.objects.len() || to_obj.0 >= self.objects.len() {
-            eprintln!(
-                "[rust4pm] warning: add_o2o called with invalid index(es) (from_obj={}, to_obj={}); ignored",
+            error!(
+                "[rust4pm]: add_o2o called with invalid index(es) (from_obj={}, to_obj={}); ignored",
                 from_obj.0, to_obj.0
             );
             return false;
@@ -751,8 +751,8 @@ impl SlimLinkedOCEL {
     /// Returns `true` on success, `false` if either index is out of bounds (with a stderr warning).
     pub fn delete_e2o(&mut self, event: &EventIndex, object: &ObjectIndex) -> bool {
         if event.0 >= self.events.len() || object.0 >= self.objects.len() {
-            eprintln!(
-                "[rust4pm] warning: delete_e2o called with invalid index(es) (event={}, object={}); ignored",
+            error!(
+                "[rust4pm] : delete_e2o called with invalid index(es) (event={}, object={}); ignored",
                 event.0, object.0
             );
             return false;
@@ -769,8 +769,8 @@ impl SlimLinkedOCEL {
     /// Returns `true` on success, `false` if either index is out of bounds (with a stderr warning).
     pub fn delete_o2o(&mut self, from_obj: &ObjectIndex, to_obj: &ObjectIndex) -> bool {
         if from_obj.0 >= self.objects.len() || to_obj.0 >= self.objects.len() {
-            eprintln!(
-                "[rust4pm] warning: delete_o2o called with invalid index(es) (from_obj={}, to_obj={}); ignored",
+            error!(
+                "[rust4pm]: delete_o2o called with invalid index(es) (from_obj={}, to_obj={}); ignored",
                 from_obj.0, to_obj.0
             );
             return false;

--- a/process_mining/src/core/event_data/object_centric/linked_ocel/slim_linked_ocel.rs
+++ b/process_mining/src/core/event_data/object_centric/linked_ocel/slim_linked_ocel.rs
@@ -3,7 +3,7 @@
 //! Allows easy and efficient access to events, objects, and their relations
 use chrono::{DateTime, FixedOffset};
 use itertools::Itertools;
-use log::{debug, error, info, trace, warn};
+use log::error;
 use macros_process_mining::RegistryEntity;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/process_mining/src/core/event_data/object_centric/ocel_csv/csv_ocel_export.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_csv/csv_ocel_export.rs
@@ -1,7 +1,7 @@
 //! CSV Export for OCEL 2.0
 use crate::core::event_data::object_centric::ocel_struct::{OCELAttributeValue, OCELObject, OCEL};
 use chrono::{DateTime, FixedOffset};
-use log::{debug, error, info, trace, warn};
+use log::error;
 use std::{
     collections::{HashMap, HashSet},
     io::Write,

--- a/process_mining/src/core/event_data/object_centric/ocel_csv/csv_ocel_export.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_csv/csv_ocel_export.rs
@@ -1,7 +1,7 @@
 //! CSV Export for OCEL 2.0
-
 use crate::core::event_data::object_centric::ocel_struct::{OCELAttributeValue, OCELObject, OCEL};
 use chrono::{DateTime, FixedOffset};
+use log::{debug, error, info, trace, warn};
 use std::{
     collections::{HashMap, HashSet},
     io::Write,
@@ -276,7 +276,7 @@ fn format_object_refs(refs: &[ObjectRef<'_>]) -> String {
                     match serde_json::to_string(attrs) {
                         Ok(json) => s.push_str(&json),
                         Err(e) => {
-                            eprintln!("Failed to serialize object attributes to JSON: {}", e);
+                            error!("Failed to serialize object attributes to JSON: {}", e);
                         }
                     }
                 }

--- a/process_mining/src/core/event_data/object_centric/ocel_csv/csv_ocel_import.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_csv/csv_ocel_import.rs
@@ -1,10 +1,10 @@
 //! CSV Import for OCEL
 
-use std::{collections::HashMap, fmt::Display, io::Read};
-
 use chrono::{DateTime, FixedOffset};
+use log::{debug, error, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use std::{collections::HashMap, fmt::Display, io::Read};
 
 use crate::core::event_data::{
     object_centric::ocel_struct::{
@@ -345,7 +345,7 @@ pub fn import_ocel_csv_with_options(
                     });
                 }
                 if options.verbose {
-                    eprintln!("Warning: Skipping row {row_num} (missing timestamp)");
+                    error!("Skipping row {row_num} (missing timestamp)");
                 }
                 continue;
             }
@@ -363,7 +363,7 @@ pub fn import_ocel_csv_with_options(
 
         if is_attr_only && timestamp.is_none() {
             if options.verbose {
-                eprintln!("Warning: Row {row_num} (attribute-only without timestamp). Will assume UNIX EPOCH as time.");
+                error!("Row {row_num} (attribute-only without timestamp). Will assume UNIX EPOCH as time.");
             }
             timestamp = Some(DateTime::UNIX_EPOCH.into());
         }
@@ -448,7 +448,7 @@ pub fn import_ocel_csv_with_options(
                         ),
                     });
                 }
-                eprintln!("Warning: O2O source '{id}' not found at row {row_num}");
+                error!("O2O source '{id}' not found at row {row_num}");
             }
             continue;
         }

--- a/process_mining/src/core/event_data/object_centric/ocel_csv/csv_ocel_import.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_csv/csv_ocel_import.rs
@@ -1,7 +1,7 @@
 //! CSV Import for OCEL
 
 use chrono::{DateTime, FixedOffset};
-use log::{debug, error, info, trace, warn};
+use log::error;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::{collections::HashMap, fmt::Display, io::Read};

--- a/process_mining/src/core/event_data/object_centric/ocel_sql/duckdb/duckdb_ocel_import.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_sql/duckdb/duckdb_ocel_import.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::core::event_data::{
     object_centric::ocel_struct::{
         OCELAttributeValue, OCELEvent, OCELEventAttribute, OCELObject, OCELObjectAttribute,
@@ -7,6 +5,8 @@ use crate::core::event_data::{
     },
     timestamp_utils::parse_timestamp,
 };
+use log::{debug, error, info, trace, warn};
+use std::collections::HashMap;
 
 use super::super::*;
 use ::duckdb::{Connection, Params, Row, Rows, Statement};
@@ -126,7 +126,6 @@ pub fn import_ocel_duckdb_from_con(con: Connection) -> Result<OCEL, ::duckdb::Er
             // Technically time should probably be set to UNIX epoch (1970-01-01 00:00 UTC) for these "initial" attribute values
             // however there are some OCEL logs for which this does not hold?
             if DateTime::UNIX_EPOCH.fixed_offset() != time {
-                // eprintln!("Expected initial object attribute value to have UNIX epoch as time. Instead got {time:?}. Overwriting to UNIX epoch.");
                 time = DateTime::UNIX_EPOCH.into();
             }
             o.attributes
@@ -154,7 +153,7 @@ pub fn import_ocel_duckdb_from_con(con: Connection) -> Result<OCEL, ::duckdb::Er
                 .iter()
                 .find(|at| at.name == changed_field)
                 .ok_or_else(|| {
-                    println!(
+                    error!(
                         "Could not get change field for {:?} in {:?}",
                         changed_field, ob_type_attrs
                     );
@@ -270,9 +269,7 @@ pub fn import_ocel_duckdb_from_con(con: Connection) -> Result<OCEL, ::duckdb::Er
                 qualifier,
             });
         } else {
-            eprintln!(
-                "Warning: E2O relationship not added as event with ID {ev_id} was not found."
-            );
+            error!("E2O relationship not added as event with ID {ev_id} was not found.");
         }
     });
 
@@ -280,23 +277,23 @@ pub fn import_ocel_duckdb_from_con(con: Connection) -> Result<OCEL, ::duckdb::Er
     let mut s = con.prepare("SELECT * FROM object_object".to_string().as_str())?;
     let evs = query_all::<_>(&mut s, [])?;
     evs.and_then(|x| {
-            Ok::<(String, String, String), ::duckdb::Error>((
-                x.get(OCEL_O2O_SOURCE_ID_COLUMN)?,
-                x.get(OCEL_O2O_TARGET_ID_COLUMN)?,
-                x.get(OCEL_REL_QUALIFIER_COLUMN)?,
-            ))
-        })
-        .flatten()
-        .for_each(|(source_ob_id, target_ob_id, qualifier)| {
-            if let Some(ev) = object_map.get_mut(&source_ob_id) {
-                ev.relationships.push(OCELRelationship {
-                    object_id: target_ob_id,
-                    qualifier,
-                });
-            }else{
-                eprintln!("Warning: O2O relationship not added as object with ID {source_ob_id} was not found.");
-            }
-        });
+        Ok::<(String, String, String), ::duckdb::Error>((
+            x.get(OCEL_O2O_SOURCE_ID_COLUMN)?,
+            x.get(OCEL_O2O_TARGET_ID_COLUMN)?,
+            x.get(OCEL_REL_QUALIFIER_COLUMN)?,
+        ))
+    })
+    .flatten()
+    .for_each(|(source_ob_id, target_ob_id, qualifier)| {
+        if let Some(ev) = object_map.get_mut(&source_ob_id) {
+            ev.relationships.push(OCELRelationship {
+                object_id: target_ob_id,
+                qualifier,
+            });
+        } else {
+            error!("O2O relationship not added as object with ID {source_ob_id} was not found.");
+        }
+    });
 
     ocel.objects = object_map.into_values().collect();
     ocel.events = event_map.into_values().collect();

--- a/process_mining/src/core/event_data/object_centric/ocel_sql/sqlite/sqlite_ocel_import.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_sql/sqlite/sqlite_ocel_import.rs
@@ -1,14 +1,14 @@
+use super::super::*;
 use crate::core::event_data::object_centric::ocel_struct::OCEL;
 use crate::core::event_data::object_centric::ocel_struct::{
     OCELAttributeValue, OCELEvent, OCELEventAttribute, OCELObject, OCELObjectAttribute,
     OCELRelationship, OCELTypeAttribute,
 };
 use crate::core::event_data::timestamp_utils::parse_timestamp;
-use std::{collections::HashMap, ffi::CString};
-
-use super::super::*;
 use chrono::FixedOffset;
+use log::{debug, error, info, trace, warn};
 use rusqlite::{Connection, Params, Row, Rows, Statement};
+use std::{collections::HashMap, ffi::CString};
 
 fn try_get_column_date_val(
     r: &Row<'_>,
@@ -262,9 +262,7 @@ pub fn import_ocel_sqlite_from_con(con: Connection) -> Result<OCEL, rusqlite::Er
                 qualifier,
             });
         } else {
-            eprintln!(
-                "Warning: E2O relationship not added as event with ID {ev_id} was not found."
-            );
+            error!("E2O relationship not added as event with ID {ev_id} was not found.");
         }
     });
 
@@ -272,23 +270,23 @@ pub fn import_ocel_sqlite_from_con(con: Connection) -> Result<OCEL, rusqlite::Er
     let mut s = con.prepare("SELECT * FROM object_object".to_string().as_str())?;
     let evs = query_all::<_>(&mut s, [])?;
     evs.and_then(|x| {
-            Ok::<(String, String, String), rusqlite::Error>((
-                x.get(OCEL_O2O_SOURCE_ID_COLUMN)?,
-                x.get(OCEL_O2O_TARGET_ID_COLUMN)?,
-                x.get(OCEL_REL_QUALIFIER_COLUMN)?,
-            ))
-        })
-        .flatten()
-        .for_each(|(source_ob_id, target_ob_id, qualifier)| {
-            if let Some(ev) = object_map.get_mut(&source_ob_id) {
-                ev.relationships.push(OCELRelationship {
-                    object_id: target_ob_id,
-                    qualifier,
-                });
-            }else{
-                eprintln!("Warning: O2O relationship not added as object with ID {source_ob_id} was not found.");
-            }
-        });
+        Ok::<(String, String, String), rusqlite::Error>((
+            x.get(OCEL_O2O_SOURCE_ID_COLUMN)?,
+            x.get(OCEL_O2O_TARGET_ID_COLUMN)?,
+            x.get(OCEL_REL_QUALIFIER_COLUMN)?,
+        ))
+    })
+    .flatten()
+    .for_each(|(source_ob_id, target_ob_id, qualifier)| {
+        if let Some(ev) = object_map.get_mut(&source_ob_id) {
+            ev.relationships.push(OCELRelationship {
+                object_id: target_ob_id,
+                qualifier,
+            });
+        } else {
+            error!("O2O relationship not added as object with ID {source_ob_id} was not found.");
+        }
+    });
 
     ocel.objects = object_map.into_values().collect();
     ocel.events = event_map.into_values().collect();

--- a/process_mining/src/core/event_data/object_centric/ocel_sql/sqlite/sqlite_ocel_import.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_sql/sqlite/sqlite_ocel_import.rs
@@ -6,7 +6,7 @@ use crate::core::event_data::object_centric::ocel_struct::{
 };
 use crate::core::event_data::timestamp_utils::parse_timestamp;
 use chrono::FixedOffset;
-use log::{debug, error, info, trace, warn};
+use log::error;
 use rusqlite::{Connection, Params, Row, Rows, Statement};
 use std::{collections::HashMap, ffi::CString};
 

--- a/process_mining/src/core/event_data/object_centric/ocel_struct.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_struct.rs
@@ -422,7 +422,7 @@ impl OCELAttributeType {
     /// For instance "string" yields [`OCELAttributeType::String`]
     ///
     /// See [`OCELAttributeType::to_type_string`] for the reverse functionality.
-    ///  
+    ///
     pub fn from_type_str(s: &str) -> Self {
         match s {
             "string" => OCELAttributeType::String,

--- a/process_mining/src/core/event_data/object_centric/ocel_xml/xml_ocel_import.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_xml/xml_ocel_import.rs
@@ -1,10 +1,10 @@
+use log::{debug, error, info, trace, warn};
+use quick_xml::{events::BytesStart, Reader};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     io::{BufRead, BufReader},
 };
-
-use quick_xml::{events::BytesStart, Reader};
-use serde::{Deserialize, Serialize};
 
 use crate::core::event_data::{
     object_centric::{
@@ -117,11 +117,10 @@ fn parse_attribute_value(
     match res {
         Ok(attribute_val) => attribute_val,
         Err(e) => {
-            if options.verbose {
-                eprintln!(
+            error!(
                     "Failed to parse attribute value {value:?} with supposed type {attribute_type:?}\n{e}"
                 );
-            }
+
             OCELAttributeValue::Null
         }
     }
@@ -249,9 +248,7 @@ where
                                         )
                                     }
                                     Err(e) => {
-                                        if options.verbose {
-                                            eprintln!("Failed to parse time value of attribute: {e}. Will skip this attribute completely for now.");
-                                        }
+                                        error!("Failed to parse time value of attribute: {e}. Will skip this attribute completely for now.");
                                     }
                                 }
                             }
@@ -444,9 +441,7 @@ where
                                         )
                                     }
                                     Err(e) => {
-                                        if options.verbose {
-                                            eprintln!("Failed to parse time value of attribute: {e}. Will skip this attribute completely for now.");
-                                        }
+                                        error!("Failed to parse time value of attribute: {e}. Will skip this attribute completely for now.");
                                     }
                                 }
                             }

--- a/process_mining/src/core/event_data/object_centric/ocel_xml/xml_ocel_import.rs
+++ b/process_mining/src/core/event_data/object_centric/ocel_xml/xml_ocel_import.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info, trace, warn};
+use log::error;
 use quick_xml::{events::BytesStart, Reader};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/process_mining/src/core/event_data/tests/xes_import_tests.rs
+++ b/process_mining/src/core/event_data/tests/xes_import_tests.rs
@@ -1,7 +1,6 @@
-use std::{fs::File, io::Read};
-
 use chrono::DateTime;
 use quick_xml::Writer;
+use std::{fs::File, io::Read};
 
 use crate::{
     core::event_data::case_centric::{

--- a/process_mining/src/core/event_data/timestamp_utils.rs
+++ b/process_mining/src/core/event_data/timestamp_utils.rs
@@ -1,6 +1,6 @@
 //! Shared timestamp parsing utilities for event data importers
-
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
+use log::{debug, error, info, trace, warn};
 
 /// Parse a timestamp string to `DateTime<FixedOffset>`, trying multiple formats.
 ///
@@ -29,7 +29,7 @@ use chrono::{DateTime, FixedOffset, NaiveDateTime};
 pub fn parse_timestamp<'a>(
     time: &'a str,
     custom_format: Option<&'a str>,
-    verbose: bool,
+    _verbose: bool, // This should be handled by logger, not by our logic. Kept with an underscore to preserve backward compatibility without breaking API consumers
 ) -> Result<DateTime<FixedOffset>, &'a str> {
     // Try custom date format first if provided
     if let Some(date_format) = custom_format {
@@ -88,9 +88,7 @@ pub fn parse_timestamp<'a>(
         return Ok(dt);
     }
 
-    if verbose {
-        eprintln!("Failed to parse timestamp: {time}");
-    }
+    error!("Failed to parse timestamp: {time}");
     Err("Unexpected timestamp format")
 }
 

--- a/process_mining/src/core/event_data/timestamp_utils.rs
+++ b/process_mining/src/core/event_data/timestamp_utils.rs
@@ -1,6 +1,6 @@
 //! Shared timestamp parsing utilities for event data importers
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
-use log::{debug, error, info, trace, warn};
+use log::error;
 
 /// Parse a timestamp string to `DateTime<FixedOffset>`, trying multiple formats.
 ///

--- a/process_mining/src/core/process_models/case_centric/petri_net/pnml/import_pnml.rs
+++ b/process_mining/src/core/process_models/case_centric/petri_net/pnml/import_pnml.rs
@@ -1,11 +1,11 @@
-use quick_xml::{Error as QuickXMLError, Reader};
-use std::{collections::HashMap, io::BufRead};
-use uuid::Uuid;
-
 use crate::core::{
     process_models::case_centric::petri_net::petri_net_struct::{ArcType, Marking, PlaceID},
     PetriNet,
 };
+use log::{debug, error, info, trace, warn};
+use quick_xml::{Error as QuickXMLError, Reader};
+use std::{collections::HashMap, io::BufRead};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Mode {
@@ -135,13 +135,13 @@ where
                 }
                 b"net" => {
                     if current_mode != Mode::Pnml {
-                        eprintln!("Expected to be in Mode::PNML when encountering net");
+                        error!("Expected to be in Mode::PNML when encountering net");
                     }
                     current_mode = Mode::Net;
                 }
                 b"page" => {
                     if current_mode != Mode::Net {
-                        eprintln!("Expected to be in Mode::Net when encountering page");
+                        error!("Expected to be in Mode::Net when encountering page");
                     }
                     current_mode = Mode::Net;
                 }
@@ -222,9 +222,7 @@ where
                                 // Set label to None (silent)
                                 trans.label = None;
                             } else {
-                                eprintln!(
-                                    "Can't find current transition when adding toolspecific!"
-                                );
+                                error!("Can't find current transition when adding toolspecific!");
                             }
                         }
                     }
@@ -288,7 +286,7 @@ where
                                 trans.label = Some(text);
                             }
                         } else {
-                            eprintln!("Can't find current transition when adding text!");
+                            error!("Can't find current transition when adding text!");
                         }
                     }
                     Mode::InitialMarking => {

--- a/process_mining/src/core/process_models/case_centric/petri_net/pnml/import_pnml.rs
+++ b/process_mining/src/core/process_models/case_centric/petri_net/pnml/import_pnml.rs
@@ -2,7 +2,7 @@ use crate::core::{
     process_models::case_centric::petri_net::petri_net_struct::{ArcType, Marking, PlaceID},
     PetriNet,
 };
-use log::{debug, error, info, trace, warn};
+use log::error;
 use quick_xml::{Error as QuickXMLError, Reader};
 use std::{collections::HashMap, io::BufRead};
 use uuid::Uuid;

--- a/process_mining/src/discovery/case_centric/alphappp/auto_parameters.rs
+++ b/process_mining/src/discovery/case_centric/alphappp/auto_parameters.rs
@@ -3,7 +3,7 @@ use crate::core::{
     event_data::case_centric::utils::activity_projection::EventLogActivityProjection,
     process_models::case_centric::petri_net::petri_net_struct::Transition, PetriNet,
 };
-use log::{debug, error, info, trace, warn};
+use log::info;
 const AUTO_CONFIGS: &[AlphaPPPConfig] = &[
     AlphaPPPConfig {
         balance_thresh: 0.6,

--- a/process_mining/src/discovery/case_centric/alphappp/auto_parameters.rs
+++ b/process_mining/src/discovery/case_centric/alphappp/auto_parameters.rs
@@ -1,9 +1,9 @@
+use super::full::{alphappp_discover_petri_net, AlphaPPPConfig};
 use crate::core::{
     event_data::case_centric::utils::activity_projection::EventLogActivityProjection,
     process_models::case_centric::petri_net::petri_net_struct::Transition, PetriNet,
 };
-
-use super::full::{alphappp_discover_petri_net, AlphaPPPConfig};
+use log::{debug, error, info, trace, warn};
 const AUTO_CONFIGS: &[AlphaPPPConfig] = &[
     AlphaPPPConfig {
         balance_thresh: 0.6,
@@ -128,8 +128,8 @@ pub fn alphappp_discover_with_auto_parameters(
         }
     }
     let (best_config, best_score, best_pn) = best.unwrap();
-    println!("Best score: {best_score:.2} with config {best_config:?}");
-    println!(
+    info!("Best score: {best_score:.2} with config {best_config:?}");
+    info!(
         "Resulting net has {} arcs, {} transitions and {} places",
         best_pn.arcs.len(),
         best_pn.transitions.len(),

--- a/process_mining/src/discovery/case_centric/alphappp/candidate_building.rs
+++ b/process_mining/src/discovery/case_centric/alphappp/candidate_building.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info, trace, warn};
+use log::info;
 use rayon::prelude::*;
 use std::collections::HashSet;
 

--- a/process_mining/src/discovery/case_centric/alphappp/candidate_building.rs
+++ b/process_mining/src/discovery/case_centric/alphappp/candidate_building.rs
@@ -1,6 +1,6 @@
-use std::collections::HashSet;
-
+use log::{debug, error, info, trace, warn};
 use rayon::prelude::*;
+use std::collections::HashSet;
 
 use crate::core::event_data::case_centric::utils::activity_projection::ActivityProjectionDFG;
 
@@ -75,7 +75,7 @@ pub fn build_candidates(dfg: &ActivityProjectionDFG) -> HashSet<(Vec<usize>, Vec
         .par_iter()
         .filter_map(|((a, b), w)| if w > &0 { Some((*a, *b)) } else { None })
         .collect();
-    println!("DF #{:?}", df_relations.len());
+    info!("DF #{:?}", df_relations.len());
     let mut cnds: HashSet<(Vec<usize>, Vec<usize>)> = HashSet::new();
     let mut final_cnds: HashSet<(Vec<usize>, Vec<usize>)> = HashSet::new();
     (0..dfg.nodes.len()).for_each(|a| {

--- a/process_mining/src/discovery/case_centric/alphappp/candidate_pruning.rs
+++ b/process_mining/src/discovery/case_centric/alphappp/candidate_pruning.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info, trace, warn};
+use log::info;
 use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::{
     cmp::max,

--- a/process_mining/src/discovery/case_centric/alphappp/candidate_pruning.rs
+++ b/process_mining/src/discovery/case_centric/alphappp/candidate_pruning.rs
@@ -1,9 +1,9 @@
+use log::{debug, error, info, trace, warn};
+use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::{
     cmp::max,
     collections::{HashMap, HashSet},
 };
-
-use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::core::event_data::case_centric::utils::activity_projection::{
     EventLogActivityProjection, END_ACTIVITY, START_ACTIVITY,
@@ -148,7 +148,7 @@ pub fn prune_candidates(
             balance <= balance_threshold
         })
         .collect();
-    println!("After balance: {}", filtered_cnds.len());
+    info!("After balance: {}", filtered_cnds.len());
     let filtered_cnds: Vec<&(Vec<usize>, Vec<usize>)> = filtered_cnds
         .into_par_iter()
         .filter(|(a, b)| {
@@ -156,7 +156,7 @@ pub fn prune_candidates(
             fitness >= fitness_threshold && min_per_act_fitness >= fitness_threshold
         })
         .collect();
-    println!("After fitness: {}", filtered_cnds.len());
+    info!("After fitness: {}", filtered_cnds.len());
 
     let sel: Vec<(Vec<usize>, Vec<usize>)> = filtered_cnds
         .par_iter()
@@ -176,7 +176,7 @@ pub fn prune_candidates(
         .map(|(a, b)| (a.clone(), b.clone()))
         .collect();
 
-    println!("After maximal (sel): {}", sel.len());
+    info!("After maximal (sel): {}", sel.len());
     sel.into_iter()
         .filter(|(a, b)| {
             let strict_fit = compute_local_fitness(a, b, log, true);

--- a/process_mining/src/discovery/case_centric/alphappp/full.rs
+++ b/process_mining/src/discovery/case_centric/alphappp/full.rs
@@ -1,11 +1,11 @@
+use log::{debug, error, info, trace, warn};
+use macros_process_mining::register_binding;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     time::{SystemTime, UNIX_EPOCH},
 };
-
-use macros_process_mining::register_binding;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::core::{
     event_data::case_centric::utils::activity_projection::{
@@ -124,7 +124,7 @@ pub fn alphappp_discover_petri_net_with_timing_fn(
     config: AlphaPPPConfig,
     get_time_millis_fn: &dyn Fn() -> u128,
 ) -> (PetriNet, AlgoDuration) {
-    println!("Started Alpha+++ Discovery");
+    info!("Started Alpha+++ Discovery");
     let mut algo_dur = AlgoDuration {
         loop_repair: 0.0,
         skip_repair: 0.0,
@@ -144,7 +144,7 @@ pub fn alphappp_discover_petri_net_with_timing_fn(
 
     let start_act = log_proj.act_to_index.get(START_ACTIVITY).unwrap();
     let end_act = log_proj.act_to_index.get(END_ACTIVITY).unwrap();
-    println!(
+    info!(
         "Adding start/end acts took: {:.4}s",
         get_time_millis_fn() - start
     );
@@ -154,11 +154,11 @@ pub fn alphappp_discover_petri_net_with_timing_fn(
         (config.log_repair_loop_df_thresh_rel * mean_dfg).ceil() as u64,
     );
     algo_dur.loop_repair = (get_time_millis_fn() - start) as f32 / 1000.0;
-    println!(
+    info!(
         "Using Loop Log Repair with df_threshold of {}",
         (config.log_repair_loop_df_thresh_rel * mean_dfg).ceil() as u64,
     );
-    println!("#Added for loop: {}", added_loop.len());
+    info!("#Added for loop: {}", added_loop.len());
 
     start = get_time_millis_fn();
     let (log_proj, added_skip) = add_artificial_acts_for_skips(
@@ -166,7 +166,7 @@ pub fn alphappp_discover_petri_net_with_timing_fn(
         (config.log_repair_skip_df_thresh_rel * mean_dfg).ceil() as u64,
     );
     algo_dur.skip_repair = (get_time_millis_fn() - start) as f32 / 1000.0;
-    println!("Log Skip/Loop Repair took: {:.4}s", algo_dur.skip_repair);
+    info!("Log Skip/Loop Repair took: {:.4}s", algo_dur.skip_repair);
     start = get_time_millis_fn();
 
     let mut act_count = vec![0_i128; log_proj.activities.len()];
@@ -175,8 +175,8 @@ pub fn alphappp_discover_petri_net_with_timing_fn(
             act_count[*act] += *w as i128;
         })
     });
-    println!("Act count: {act_count:?}");
-    println!(
+    info!("Act count: {act_count:?}");
+    debug!(
         "Acts: {:?}",
         log_proj
             .activities
@@ -185,26 +185,26 @@ pub fn alphappp_discover_petri_net_with_timing_fn(
             .collect::<Vec<(&String, i128)>>()
     );
 
-    println!("#Added for skip: {}", added_skip.len());
+    info!("#Added for skip: {}", added_skip.len());
     let dfg = ActivityProjectionDFG::from_event_log_projection(&log_proj);
     let dfg = filter_dfg(
         &dfg,
         config.absolute_df_clean_thresh,
         config.relative_df_clean_thresh,
     );
-    println!(
+    info!(
         "Filtered DFG (aDFG) #Edges: {}, Weight Sum: {}",
         dfg.edges.len(),
         dfg.edges.values().sum::<u64>()
     );
     algo_dur.filter_dfg = (get_time_millis_fn() - start) as f32 / 1000.0;
-    println!("Filtering DFG took: {:.4}s", algo_dur.filter_dfg);
+    info!("Filtering DFG took: {:.4}s", algo_dur.filter_dfg);
     start = get_time_millis_fn();
     let cnds: HashSet<(Vec<usize>, Vec<usize>)> = build_candidates(&dfg);
-    println!("Built candidates {}", cnds.len());
+    info!("Built candidates {}", cnds.len());
 
     algo_dur.cnd_building = (get_time_millis_fn() - start) as f32 / 1000.0;
-    println!("Building candidates took: {:.4}s", algo_dur.cnd_building);
+    info!("Building candidates took: {:.4}s", algo_dur.cnd_building);
     start = get_time_millis_fn();
     let sel = prune_candidates(
         &cnds,
@@ -221,9 +221,9 @@ pub fn alphappp_discover_petri_net_with_timing_fn(
     //     b.sort();
     //     println!("{:?} => {:?}", a,b);
     // });
-    println!("Final pruned candidates: {}", sel.len());
+    info!("Final pruned candidates: {}", sel.len());
     algo_dur.prune_cnd = (get_time_millis_fn() - start) as f32 / 1000.0;
-    println!("Pruning candidates took: {:.4}s", algo_dur.prune_cnd);
+    info!("Pruning candidates took: {:.4}s", algo_dur.prune_cnd);
     start = get_time_millis_fn();
     let mut pn = PetriNet::new();
     let mut initial_marking: Marking = Marking::new();
@@ -283,10 +283,10 @@ pub fn alphappp_discover_petri_net_with_timing_fn(
     pn.initial_marking = Some(initial_marking);
     pn.final_markings = Some(vec![final_marking]);
     algo_dur.build_net = (get_time_millis_fn() - start) as f32 / 1000.0;
-    println!("Building PN took: {:.4}s", algo_dur.build_net);
+    info!("Building PN took: {:.4}s", algo_dur.build_net);
 
     algo_dur.total = (get_time_millis_fn() - total_start) as f32 / 1000.0;
-    println!("\n====\nWhole Discovery took: {:.4}s", algo_dur.total);
+    info!("\n====\nWhole Discovery took: {:.4}s", algo_dur.total);
     (pn, algo_dur)
 }
 

--- a/process_mining/src/discovery/case_centric/alphappp/full.rs
+++ b/process_mining/src/discovery/case_centric/alphappp/full.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info, trace, warn};
+use log::{debug, info};
 use macros_process_mining::register_binding;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/process_mining/src/discovery/object_centric/oc_declare/mod.rs
+++ b/process_mining/src/discovery/object_centric/oc_declare/mod.rs
@@ -1,11 +1,10 @@
 //! Discovering OC-DECLARE Models from Object-Centric Event Data
-use std::collections::{HashMap, HashSet, VecDeque};
-
 use itertools::Itertools;
 use macros_process_mining::register_binding;
 use rayon::prelude::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::{
     conformance::oc_declare::get_for_all_evs_perf_thresh,

--- a/process_mining/src/lib.rs
+++ b/process_mining/src/lib.rs
@@ -7,6 +7,9 @@
     clippy::clone_on_copy
 )]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::print_stdout)]
+#![deny(clippy::print_stderr)]
+#![cfg_attr(test, allow(clippy::print_stdout, clippy::print_stderr))]
 
 pub mod analysis;
 pub mod conformance;

--- a/r4pm/Cargo.toml
+++ b/r4pm/Cargo.toml
@@ -12,4 +12,6 @@ process_mining = { version = "0.5.5", path = "../process_mining", features = ["b
 serde_json = "1.0.105"
 serde = { version = "1.0.188", features = ["derive"] }
 anstyle = "1.0.13"
+log = "0.4.29"
+env_logger = "0.11.10"
 

--- a/r4pm/src/main.rs
+++ b/r4pm/src/main.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashSet, path::PathBuf, process::ExitCode, sync::LazyLock};
-
 use anstyle::AnsiColor;
+use log::{debug, error, info, trace, warn};
 pub use process_mining::bindings;
 use process_mining::bindings::Binding;
+use std::{collections::HashSet, path::PathBuf, process::ExitCode, sync::LazyLock};
 
 static SPACE: &str = "  ";
 static CLI_NAME: &str = "r4pm";
@@ -54,10 +54,11 @@ fn bold(s: impl std::fmt::Display) -> String {
 }
 
 fn main() -> ExitCode {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let functions = bindings::list_functions();
     let args: Vec<String> = std::env::args().collect();
     if args.len() <= 1 {
-        println!(
+        error!(
             "{}\nAvailable functions: {}",
             warn(format!("Usage: {CLI_NAME} fun_name --arg1 'abc' --arg2 4")),
             functions
@@ -73,7 +74,7 @@ fn main() -> ExitCode {
     let func_name = &args[1];
     let binding = functions.iter().find(|f| f.name == func_name);
     if binding.is_none() {
-        println!("Unknown function: {func_name}");
+        error!("Unknown function: {func_name}");
         return ExitCode::FAILURE;
     }
     let binding = binding.unwrap();
@@ -99,7 +100,7 @@ fn main() -> ExitCode {
                             params.insert(arg_name.to_string(), resolved_value);
                         }
                         Err(e) => {
-                            eprintln!(
+                            error!(
                                 "{}",
                                 warn(format!("Error resolving argument '{}': {}", arg_name, e))
                             );
@@ -117,7 +118,7 @@ fn main() -> ExitCode {
                 output_path = Some(PathBuf::from(arg));
             } else {
                 // Unknown argument?!
-                eprintln!("{}", warn(format!("Unknown argument: {:?}", arg)));
+                error!("{}", warn(format!("Unknown argument: {:?}", arg)));
                 return ExitCode::FAILURE;
             }
         }
@@ -128,7 +129,7 @@ fn main() -> ExitCode {
         .filter(|k| !params.contains_key(k))
         .collect();
     if !missing_args.is_empty() {
-        eprintln!(
+        error!(
             "{}",
             warn(format!(
                 "Missing required arguments: {}",
@@ -146,10 +147,10 @@ fn main() -> ExitCode {
                     if let Some(item) = state_guard.get(id) {
                         match item.export_to_path(&output_path) {
                             Ok(_) => {
-                                println!("Exported registry item '{}' to {:?}", id, output_path);
+                                info!("Exported registry item '{}' to {:?}", id, output_path);
                             }
                             Err(e) => {
-                                eprintln!(
+                                error!(
                                     "{}",
                                     warn(format!("Failed to export registry item: {}", e))
                                 );
@@ -181,7 +182,7 @@ fn main() -> ExitCode {
             }
         }
         Err(e) => {
-            eprintln!("{}", warn(format!("Error calling function: {}", e)));
+            error!("{}", warn(format!("Error calling function: {}", e)));
             return ExitCode::FAILURE;
         }
     }

--- a/r4pm/src/main.rs
+++ b/r4pm/src/main.rs
@@ -1,5 +1,9 @@
+#![deny(clippy::print_stdout)]
+#![deny(clippy::print_stderr)]
+#![cfg_attr(test, allow(clippy::print_stdout, clippy::print_stderr))]
+
 use anstyle::AnsiColor;
-use log::{debug, error, info, trace, warn};
+use log::{error, info};
 pub use process_mining::bindings;
 use process_mining::bindings::Binding;
 use std::{collections::HashSet, path::PathBuf, process::ExitCode, sync::LazyLock};
@@ -178,7 +182,10 @@ fn main() -> ExitCode {
                         final_res = val;
                     }
                 }
-                println!("{}", serde_json::to_string_pretty(&final_res).unwrap());
+                #[allow(clippy::print_stdout)]
+                {
+                    println!("{}", serde_json::to_string_pretty(&final_res).unwrap());
+                }
             }
         }
         Err(e) => {
@@ -189,6 +196,7 @@ fn main() -> ExitCode {
     ExitCode::SUCCESS
 }
 
+#[allow(clippy::print_stdout)]
 fn print_function_info(binding: &Binding, required_fn_args: &HashSet<String>) {
     let name = binding.name;
 


### PR DESCRIPTION
### Summary
This PR transitions the codebase away from raw standard output/error macros (`println!` and `eprintln!`) in favor of structured logging macros (`debug!`, `info!`, `error!`), and enforces this project-wide using automated Clippy lints.

### Changes
* **Crate Roots (`lib.rs` / `main.rs`):** Added `#![deny(clippy::print_stdout)]` and `#![deny(clippy::print_stderr)]` to ensure no future print statements accidentally leak into production code or corrupt data pipelines.
* **Logging Migration:** Replaced production invocations of `println!` and `eprintln!` with contextual logging macros (`debug!`, `info!`, or `error!`) as appropriate.
* **Test Insulation:** Added `#![cfg_attr(test, allow(clippy::print_stdout, clippy::print_stderr))]` to the crate roots. This ensures that existing test suites, benchmarks, and integration tests can still use print macros for local failure diagnostics without failing the strict CI/CD lint steps.
* **CLI Output Exception:** Wrapped the final JSON output macro in `main.rs` inside an explicit `#[allow(clippy::print_stdout)]` block expression to preserve the user-facing CLI behavior while keeping the rest of the binary protected.