### PR TITLE
perf : optimized creating hashset from EventLog in convert_log_to_dataframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+dhat*.json
+perf.data
+flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,8 @@ resolver = "2"
 members = ["macros_process_mining",
 	"process_mining", "r4pm",
 ]
+[profile.bench]
+opt-level = 3
+lto = "thin"
+codegen-units = 2
+debug = 1

--- a/process_mining/src/core/event_data/case_centric/dataframe/mod.rs
+++ b/process_mining/src/core/event_data/case_centric/dataframe/mod.rs
@@ -1,11 +1,10 @@
 //! Conversion of Event Data from/to polars `DataFrame`s
 //!
 //! 🔐 Requires the `dataframes` feature to be enabled.
-use std::{collections::HashSet, time::Instant};
-
 use chrono::DateTime;
 use polars::prelude::*;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use std::{collections::HashSet, time::Instant};
 
 use crate::core::{
     event_data::case_centric::{
@@ -90,26 +89,29 @@ pub fn convert_log_to_dataframe(
     let all_attributes: HashSet<String> = log
         .traces
         .par_iter()
-        .flat_map(|t| {
-            let trace_attrs: HashSet<String> = t
-                .attributes
-                .iter()
-                .map(|a| TRACE_PREFIX.to_string() + a.key.as_str())
-                .collect();
-            let m: HashSet<String> = t
-                .events
-                .iter()
-                .flat_map(|e| {
-                    e.attributes
-                        .iter()
-                        .map(|a| a.key.clone())
-                        .collect::<Vec<String>>()
-                })
-                .collect();
-            [trace_attrs, m]
-        })
-        .flatten()
-        .collect();
+        .fold(
+            || HashSet::new(),
+            |mut acc_set: HashSet<String>, trace| {
+                for a in &trace.attributes {
+                    acc_set.insert(format!("{}{}", TRACE_PREFIX, a.key));
+                }
+                for event in &trace.events {
+                    for a in &event.attributes {
+                        if !acc_set.contains(&a.key) {
+                            acc_set.insert(a.key.clone());
+                        }
+                    }
+                }
+                acc_set
+            },
+        )
+        .reduce(
+            || HashSet::new(),
+            |mut set1, set2| {
+                set1.extend(set2);
+                set1
+            },
+        );
     if print_debug {
         println!("Gathering all attributes took {:.2?}", now.elapsed());
     }


### PR DESCRIPTION
### Performance Improvements
Optimized the initial dataframe creation phase from `event_log`
| Metric | OLD | NEW | Improvement |
| :--- | :--- | :--- | :--- |
| **Total Allocations** | 11.77M blocks | 3.23M blocks | **~72.6% reduction** |
| **Total Bytes Allocated** | 3.00 GB | 2.33 GB | **~22.6% reduction** |
| **Peak Usage (t-gmax)** | 504 MB | 430 MB | **~14.8% reduction** |
| **Final State (t-end)** | 205 KB | 205 KB | **No change** |
Reduced the time required to create the hashset from ~200ms to ~20ms 