### PR TITLE
ci: upgrade GitHub Actions dependencies to resolve deprecation warnings

### DIFF
--- a/.github/workflows/test.linux.yml
+++ b/.github/workflows/test.linux.yml
@@ -2,90 +2,89 @@ name: Test on Linux (incl. all features, linting, formatting)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   Test:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        source "$HOME/.cargo/env"  
-    - name: Install Graphviz
-      run: sudo apt-get update && sudo apt-get -y install graphviz p7zip-full
-    - name: Download DuckDB
-      run: wget -O libduckdb-linux-amd64.zip https://github.com/duckdb/duckdb/releases/download/$DUCKDB_VERSION/libduckdb-linux-amd64.zip
-      env:
+      - uses: actions/checkout@v6
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
+      - name: Install Graphviz
+        run: sudo apt-get update && sudo apt-get -y install graphviz p7zip-full
+      - name: Download DuckDB
+        run: wget -O libduckdb-linux-amd64.zip https://github.com/duckdb/duckdb/releases/download/$DUCKDB_VERSION/libduckdb-linux-amd64.zip
+        env:
           DUCKDB_VERSION: v1.3.2
-    - name: Unpacking duckdb
-      run: 7z x  ${{ github.workspace }}/libduckdb-linux-amd64.zip -o${{ github.workspace }}/libduckdb
-    - name: Download kuzudb
-      run: wget -O kuzu.zip https://github.com/kuzudb/kuzu/releases/download/$KUZU_VERSION/libkuzu-linux-x86_64.tar.gz
-      env:
-        KUZU_VERSION: v0.11.2
-    - name: Unpacking kuzudb
-      run: mkdir ${{ github.workspace }}/libkuzu && tar xzf  ${{ github.workspace }}/kuzu.zip -C ${{ github.workspace }}/libkuzu
-    - name: Downloading test files
-      run: wget -O process_mining/test_data/out.zip https://rwth-aachen.sciebo.de/s/4cvtTU3lLOgtxt1/download
-    - name: Unpacking test files
-      run: 7z x process_mining/test_data/out.zip -oprocess_mining/test_data
-    - name: Build
-      run: source "$HOME/.cargo/env" && cargo build --verbose --all-features
-      working-directory: ./process_mining
-      env:
-        DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
-        DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
-        LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
-        KUZU_SHARED: 1
-        KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
-        KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
-    - name: Clippy
-      working-directory: ./process_mining
-      run: source "$HOME/.cargo/env" && cargo clippy --all-targets --all-features -- -D warnings
-      env:
-        DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
-        DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
-        LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
-        KUZU_SHARED: 1
-        KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
-        KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
-    - name: Check formatting
-      working-directory: ./process_mining
-      run: source "$HOME/.cargo/env" && cargo fmt --all --check
-      env:
-        DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
-        DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
-        LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
-        KUZU_SHARED: 1
-        KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
-        KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
-    - name: Check docs
-      working-directory: ./process_mining
-      run: source "$HOME/.cargo/env" && cargo doc --all-features --no-deps
-      env:
-        DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
-        DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
-        LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
-        KUZU_SHARED: 1
-        KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
-        KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
-        RUSTDOCFLAGS: -D warnings
-    - name: Run tests
-      run: source "$HOME/.cargo/env" && cargo test --verbose --all-features
-      working-directory: ./process_mining
-      env:
-        DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
-        DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
-        LD_LIBRARY_PATH: $LD_LIBRARY_PATH:${{ github.workspace }}/libkuzu/:${{ github.workspace }}/libduckdb/
-        KUZU_SHARED: 1
-        KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
-        KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
+      - name: Unpacking duckdb
+        run: 7z x  ${{ github.workspace }}/libduckdb-linux-amd64.zip -o${{ github.workspace }}/libduckdb
+      - name: Download kuzudb
+        run: wget -O kuzu.zip https://github.com/kuzudb/kuzu/releases/download/$KUZU_VERSION/libkuzu-linux-x86_64.tar.gz
+        env:
+          KUZU_VERSION: v0.11.2
+      - name: Unpacking kuzudb
+        run: mkdir ${{ github.workspace }}/libkuzu && tar xzf  ${{ github.workspace }}/kuzu.zip -C ${{ github.workspace }}/libkuzu
+      - name: Downloading test files
+        run: wget -O process_mining/test_data/out.zip https://rwth-aachen.sciebo.de/s/4cvtTU3lLOgtxt1/download
+      - name: Unpacking test files
+        run: 7z x process_mining/test_data/out.zip -oprocess_mining/test_data
+      - name: Build
+        run: source "$HOME/.cargo/env" && cargo build --verbose --all-features
+        working-directory: ./process_mining
+        env:
+          DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
+          DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
+          LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
+          KUZU_SHARED: 1
+          KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
+          KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
+      - name: Clippy
+        working-directory: ./process_mining
+        run: source "$HOME/.cargo/env" && cargo clippy --all-targets --all-features -- -D warnings
+        env:
+          DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
+          DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
+          LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
+          KUZU_SHARED: 1
+          KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
+          KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
+      - name: Check formatting
+        working-directory: ./process_mining
+        run: source "$HOME/.cargo/env" && cargo fmt --all --check
+        env:
+          DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
+          DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
+          LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
+          KUZU_SHARED: 1
+          KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
+          KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
+      - name: Check docs
+        working-directory: ./process_mining
+        run: source "$HOME/.cargo/env" && cargo doc --all-features --no-deps
+        env:
+          DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
+          DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
+          LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
+          KUZU_SHARED: 1
+          KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
+          KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu
+          RUSTDOCFLAGS: -D warnings
+      - name: Run tests
+        run: source "$HOME/.cargo/env" && cargo test --verbose --all-features
+        working-directory: ./process_mining
+        env:
+          DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
+          DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
+          LD_LIBRARY_PATH: $LD_LIBRARY_PATH:${{ github.workspace }}/libkuzu/:${{ github.workspace }}/libduckdb/
+          KUZU_SHARED: 1
+          KUZU_LIBRARY_DIR: ${{ github.workspace }}/libkuzu
+          KUZU_INCLUDE_DIR: ${{ github.workspace }}/libkuzu

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -2,9 +2,9 @@ name: Test on macOS
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   Test:
@@ -16,24 +16,31 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v6
+
+      # 1. Replaced actions-rs/toolchain with dtolnay's maintained action
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
-      - uses: actions/cache@v4
+
+      - uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Downloading test files
         run: wget -O process_mining/test_data/out.zip https://rwth-aachen.sciebo.de/s/4cvtTU3lLOgtxt1/download
+
+      # 2. Replaced 7z command with native macOS unzip to prevent potential path/tooling issues
       - name: Unpacking test files
-        run: 7z x process_mining/test_data/out.zip -oprocess_mining/test_data
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib -p process_mining
+        run: unzip -q process_mining/test_data/out.zip -d process_mining/test_data
+
+      # 3. Replaced actions-rs/cargo with native cargo execution
+      - name: Run tests
+        run: cargo test --lib -p process_mining

--- a/.github/workflows/test.macos.yml
+++ b/.github/workflows/test.macos.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # 1. Replaced actions-rs/toolchain with dtolnay's maintained action
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -37,10 +36,8 @@ jobs:
       - name: Downloading test files
         run: wget -O process_mining/test_data/out.zip https://rwth-aachen.sciebo.de/s/4cvtTU3lLOgtxt1/download
 
-      # 2. Replaced 7z command with native macOS unzip to prevent potential path/tooling issues
       - name: Unpacking test files
         run: unzip -q process_mining/test_data/out.zip -d process_mining/test_data
 
-      # 3. Replaced actions-rs/cargo with native cargo execution
       - name: Run tests
         run: cargo test --lib -p process_mining

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -2,42 +2,50 @@ name: Test on Windows
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   Test:
     strategy:
       matrix:
-        os: [ windows-latest ]
-        rust: [ stable ]
+        os: [windows-latest]
+        rust: [stable]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
+
       - uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            process_mining/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      # Using native curl avoids chocolatey network overhead
       - name: Downloading test files
         run: |
-          choco install wget --no-progress
-          wget.exe -O process_mining/test_data/out.zip https://rwth-aachen.sciebo.de/s/4cvtTU3lLOgtxt1/download
+          curl -sSfL -o process_mining/test_data/out.zip https://rwth-aachen.sciebo.de/s/4cvtTU3lLOgtxt1/download
+
       - name: Unpacking test files
-        run: 7z.exe x process_mining/test_data/out.zip -oprocess_mining/test_data
+        run: 7z.exe x process_mining/test_data/out.zip -oprocess_mining/test_data -y
+
       - name: Build
         run: cargo build --verbose
         working-directory: ./process_mining
+
       - name: Run tests
         run: cargo test --verbose
         working-directory: ./process_mining

--- a/.github/workflows/test.windows.yml
+++ b/.github/workflows/test.windows.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index
@@ -34,7 +34,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      # Using native curl avoids chocolatey network overhead
       - name: Downloading test files
         run: |
           curl -sSfL -o process_mining/test_data/out.zip https://rwth-aachen.sciebo.de/s/4cvtTU3lLOgtxt1/download


### PR DESCRIPTION
### Context
Noticed deprecation/Node.js version warnings running during the CI test actions phase. 

### Changes
* Upgraded GitHub Actions versions in `.github/workflows/` to their latest stable releases to eliminate runtime warnings and ensure compatibility.

### Verification
* Actions verified locally/via fork run.