### PR TITLE
upgraded dependencies to fix vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,9 +489,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -921,12 +921,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3030,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.1",
@@ -3338,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -3356,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3486,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4026,9 +4026,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4099,30 +4099,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## PR Description: Security Sweep & Dependency Audit (`cargo update`)

### Summary
This PR runs an audit on our pinned dependencies and updates `Cargo.lock` to resolve 10 active security vulnerabilities (CVEs/RUSTSEC advisories) that have accumulated over the last two months. 

---

### Key Vulnerabilities Resolved
All resolved issues are non-breaking patch or minor updates that were automatically handled via `cargo update`:

* **`tar` (RUSTSEC-2026-0067, RUSTSEC-2026-0068):** Fixed a medium-severity symlink traversal flaw where `unpack_in` could modify arbitrary directories, and a bug ignoring PAX size headers. Essential for processing archived external datasets safely.
* **`quinn-proto` (RUSTSEC-2026-0037):** Resolved a high-severity (8.7) Denial of Service vector in network endpoints.
* **`rustls-webpki` (RUSTSEC-2026-0049, -0098, -0099, -0104):** Patched a series of certificate validation flaws, incorrect wildcard matching, and a reachable parser panic.
* **`bytes` (RUSTSEC-2026-0007):** Patched an integer overflow vulnerability in `BytesMut::reserve`.
* **`time` (RUSTSEC-2026-0009):** Fixed a stack exhaustion Denial of Service vulnerability.
* **`rkyv` (RUSTSEC-2026-0001):** Fixed potential Undefined Behavior in `Arc<T>`/`Rc<T>` implementations of `from_value` on Out-Of-Memory (OOM) conditions.
* **`array-init-cursor` (RUSTSEC-2025-0019):** Routed around a yanked, unsound sub-dependency that caused potential Undefined Behavior when dropping types.

---

### Audit Scans & Logs

#### 1. Pre-Update Scan (`cargo audit`)
```text
Scanning Cargo.lock for vulnerabilities (474 crate dependencies)

Crate:     bytes
Version:   1.10.1
Title:     Integer overflow in `BytesMut::reserve`
ID:        RUSTSEC-2026-0007
Solution:  Upgrade to >=1.11.1

Crate:     quinn-proto
Version:   0.11.13
Title:     Denial of service in Quinn endpoints
ID:        RUSTSEC-2026-0037
Severity:  8.7 (high)
Solution:  Upgrade to >=0.11.14

Crate:     rkyv
Version:   0.7.45
Title:     Potential Undefined Behaviors in `Arc<T>`/`Rc<T>` impls of `from_value` on OOM
ID:        RUSTSEC-2026-0001
Solution:  Upgrade to >=0.7.46, <0.8.0 OR >=0.8.13

Crate:     rustls-webpki
Version:   0.103.7
Title:     Multiple certificate validation & parsing flaws (CRLs, Wildcards, URI Name Constraints)
ID:        RUSTSEC-2026-0049, RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104
Solution:  Upgrade to >=0.103.13

Crate:     tar
Version:   0.4.44
Title:     PAX size header handling & symlink traversal directory modification in `unpack_in`
ID:        RUSTSEC-2026-0067, RUSTSEC-2026-0068
Severity:  5.1 (medium)
Solution:  Upgrade to >=0.4.45

Crate:     time
Version:   0.3.36
Title:     Denial of Service via Stack Exhaustion
ID:        RUSTSEC-2026-0009
Severity:  6.8 (medium)
Solution:  Upgrade to >=0.3.47

error: 10 vulnerabilities found!
warning: 6 allowed warnings found

post update 
warning: 6 allowed warnings found
